### PR TITLE
fix URL for readthedocs documentation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,6 @@ To build the docs yourself, you should install a recent version of Sphinx (works
 Automatic generation
 --------------------
 
-Within a few seconds, updated docs will be available at http://readthedocs.org/projects/baoilleach/open-babel/. Note that these docs are missing the links to the C++ documentation and to Pybel.
+Within a few seconds, updated docs will be available at https://open-babel.readthedocs.io/en/latest/. Note that these docs are missing the links to the C++ documentation and to Pybel.
 
 The complete docs are automatically generated once an hour (on the hour) from the latest source, and are available at http://openbabel.org/docs/dev.


### PR DESCRIPTION
earlier link (http://readthedocs.org/projects/baoilleach/open-babel/) does not work, I think this (https://open-babel.readthedocs.io/en/latest/) is the right one.